### PR TITLE
Add overlaps() method to IPv4Network and IPv6Network

### DIFF
--- a/netsome/types/ipv4.py
+++ b/netsome/types/ipv4.py
@@ -400,6 +400,46 @@ class IPv4Network:
 
         return self.netaddress <= address <= self.broadcast
 
+    def overlaps(self, other: "IPv4Network") -> bool:
+        """
+        Check if this network overlaps with another network.
+
+        Two networks overlap if one contains the other, they are equal,
+        or they share any addresses.
+
+        Args:
+            other: Another IPv4Network to check for overlap
+
+        Returns:
+            True if the networks overlap, False otherwise
+
+        Raises:
+            TypeError: If other is not an IPv4Network
+
+        Examples:
+            >>> net1 = IPv4Network("192.168.0.0/16")
+            >>> net2 = IPv4Network("192.168.1.0/24")
+            >>> net1.overlaps(net2)
+            True
+            >>> net3 = IPv4Network("10.0.0.0/8")
+            >>> net1.overlaps(net3)
+            False
+        """
+        if not isinstance(other, self.__class__):
+            raise TypeError(
+                f'Unable to process value "{other}" of type "{type(other)}"'
+            )
+
+        # Networks overlap if one contains the other's network address
+        # or if they are equal
+        if self == other:
+            return True
+
+        # Check if either network contains the other's network address
+        return self.contains_address(other.netaddress) or other.contains_address(
+            self.netaddress
+        )
+
 
 class IPv4Interface:
     """

--- a/netsome/types/ipv6.py
+++ b/netsome/types/ipv6.py
@@ -444,6 +444,46 @@ class IPv6Network:
         mask = int(self._netmask)
         return (int(address) & mask) == (int(self._netaddr) & mask)
 
+    def overlaps(self, other: "IPv6Network") -> bool:
+        """
+        Check if this network overlaps with another network.
+
+        Two networks overlap if one contains the other, they are equal,
+        or they share any addresses.
+
+        Args:
+            other: Another IPv6Network to check for overlap
+
+        Returns:
+            True if the networks overlap, False otherwise
+
+        Raises:
+            TypeError: If other is not an IPv6Network
+
+        Examples:
+            >>> net1 = IPv6Network("2001:db8::/32")
+            >>> net2 = IPv6Network("2001:db8::/48")
+            >>> net1.overlaps(net2)
+            True
+            >>> net3 = IPv6Network("2001:db9::/32")
+            >>> net1.overlaps(net3)
+            False
+        """
+        if not isinstance(other, self.__class__):
+            raise TypeError(
+                f'Unable to process value "{other}" of type "{type(other)}"'
+            )
+
+        # Networks overlap if one contains the other's network address
+        # or if they are equal
+        if self == other:
+            return True
+
+        # Check if either network contains the other's network address
+        return self.contains_address(other.netaddress) or other.contains_address(
+            self.netaddress
+        )
+
 
 class IPv6Interface:
     """


### PR DESCRIPTION
Check if two networks overlap (share any addresses). Includes tests covering equal networks, supernet/subnet relationships, separate networks, adjacent networks, and type error handling.