### PR TITLE
Support sub-interfaces on xe/ce interface types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,9 @@ celerybeat.pid
 # SageMath parsed files
 *.sage.py
 
+# uv
+uv.lock
+
 # Environments
 .env
 .venv

--- a/netsome/constants.py
+++ b/netsome/constants.py
@@ -156,11 +156,11 @@ IFACE_PATTERNS = {
         re.IGNORECASE,
     ),
     IFACE_TYPES.XE: re.compile(
-        rf"^xe{IFACE_VAL_PATTERN.VAL_EXTENDED.value.pattern}$",
+        rf"^xe{IFACE_VAL_PATTERN.VAL_SUB_IFACE.value.pattern}$",
         re.IGNORECASE,
     ),
     IFACE_TYPES.CE: re.compile(
-        rf"^ce{IFACE_VAL_PATTERN.VAL_EXTENDED.value.pattern}$",
+        rf"^ce{IFACE_VAL_PATTERN.VAL_SUB_IFACE.value.pattern}$",
         re.IGNORECASE,
     ),
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ license = "X11 License Distribution Modification Variant"
 name = "netsome"
 readme = "README.md"
 repository = "https://github.com/kuderr/netsome"
-version = "0.4.4"
+version = "0.4.5"
 
 [tool.poetry.dependencies]
 python = "^3.10"

--- a/tests/types/test_interfaces.py
+++ b/tests/types/test_interfaces.py
@@ -156,6 +156,22 @@ def test_interface_equality(basic_interface):
             "canonical": "ce2/1/3",
             "abbreviated": "ce2/1/3",
         },
+        {
+            "input": "xe2/1.5",
+            "type": c.IFACE_TYPES.XE,
+            "value": "2/1.5",
+            "sub": "5",
+            "canonical": "xe2/1.5",
+            "abbreviated": "xe2/1.5",
+        },
+        {
+            "input": "ce1/2.100",
+            "type": c.IFACE_TYPES.CE,
+            "value": "1/2.100",
+            "sub": "100",
+            "canonical": "ce1/2.100",
+            "abbreviated": "ce1/2.100",
+        },
     ),
 )
 def test_interface_variations_extended(test_case):


### PR DESCRIPTION
## Summary
- Switch `XE`/`CE` patterns from `VAL_EXTENDED` to `VAL_SUB_IFACE` so `xe2/1.5`, `ce1/2.100` (and similar) parse correctly, matching the Ethernet/GE/FE/Vlan patterns and how these names appear on ocnos/Netris hardware
- Add regression tests for `xe2/1.5` and `ce1/2.100`
- Gitignore `uv.lock` and bump version to 0.4.5

## Test plan
- [x] `pytest` — 1082 passed (incl. 2 new sub-interface cases)
- [x] `ruff check` / `ruff format --check` — clean
- [x] `toml-sort --check pyproject.toml` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)